### PR TITLE
Melhorada a página de edições dinâmica listando os .html das edições passadas

### DIFF
--- a/edicoes/index.php
+++ b/edicoes/index.php
@@ -1,3 +1,4 @@
+<?php include_once('index_action.php'); ?>
 <!DOCTYPE html>
 <html>
 	<head>
@@ -51,13 +52,11 @@
 			<section>
 				<h3 class="subpage_title">Edições anteriores</h3>
 				<ul>
-					<li><a class="subpage_links" target="_blank" href="edicao1.html">Edição 1</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao2.html">Edição 2</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao3.html">Edição 3</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao4.html">Edição 4</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao5.html">Edição 5</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao6.html">Edição 6</a></li>
-					<li><a class="subpage_links" target="_blank" href="edicao7.html">Edição 7</a></li>
+				    <?php $i = 1; ?>
+					<?php foreach ($files as $file){ ?>
+							<li><a class="subpage_links" target="_blank" href="<?=$file?>">Edição <?=$i?></a></li>
+							<?php $i++; ?>
+					<?php } ?>
 				</ul>
 			</section>
 		</div>

--- a/edicoes/index_action.php
+++ b/edicoes/index_action.php
@@ -1,0 +1,22 @@
+<?php 
+
+		//Arquivos de email já existentes serão listados 
+		$files = scandir("../edicoes/");
+		$name_file_parts = null;
+		$i = 0;
+
+		//Filtrando para que só os .html apareçam, diminuindo a possibilidade de que seja listado algo que não se deseja
+		foreach ($files as $name_file) {
+				
+				$name_file_parts = explode(".",$name_file);
+
+				if($name_file_parts[1] !== "html"){
+					unset($files[$i]);
+				}
+
+				$i++;
+
+		}
+
+
+?>


### PR DESCRIPTION
Foi criado um código simples em PHP para listar dinamicamente as edições anteriores de acordo com os arquivos .html existentes no diretório edições. 
Para que o código funcione corretamente, o padrão de nomenclatura, assim como a extensão do arquivo deve ser seguidos.
A página anterior (index.html), devido a essas mudanças, foi substituída por uma página .php (index.php). 
